### PR TITLE
include files needed for installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+recursive-include Products *
+recursive-include docs *
+include *
+global-exclude *.pyc


### PR DESCRIPTION
How was anyone using this package?

`setup.py` attempts to read `README.txt` and `HISTORY.txt`, but neither is included in the package available from PyPI. This manifest may be a little _too_ inclusive, but it gets the job done.
